### PR TITLE
Fix: .cache/babel-loader generating extraneous files on save #24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
added ` node_modules/ ` to `.gitignore` file on root directory