### PR TITLE
Apply styles.css to both MenuBar.vue and TenseTable.vue #29

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <link rel="stylesheet" href="../src/assets/styles.css">
 
     <title>Tense Table
       <!-- <%= htmlWebpackPlugin.options.title %> -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,13 +18,5 @@ export default {
 }
 </script>
 
-<style>
-#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: orange;
-  margin-top: 60px;
-}
-</style>
+<style src="../src/assets/styles.css">
+


### PR DESCRIPTION
Goal: apply CSS in `styles.css` for `MenuBar.vue` and `TenseTable.vue`.

Now: 
<img width="1467" alt="image" src="https://user-images.githubusercontent.com/85994674/190956657-ebe4035a-f14a-411e-974a-7e6a8531d313.png">


Problem: 

<img width="517" alt="image" src="https://user-images.githubusercontent.com/85994674/190955560-c418a637-b3e8-48c6-a428-a81ad98e00c4.png">

> Refused to apply style from 'http://localhost:8080/src/assets/styles.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.

Possibly helpful links:
https://stackoverflow.com/questions/52671245/vue-cli-how-to-import-scripts-and-styles