### PR TITLE
Click correct cell to add 1 to score #47

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -42,6 +42,16 @@ nav ul li {
     margin-inline: 2rem;
 }
 
+#answer {
+    color: var(--keyword-color);
+}
+
+#next-question {
+    position: relative;
+    left: 45%;
+    margin-block-start: 10px;
+}
+
 a {
     text-decoration: none;
 }

--- a/src/components/TenseTable.vue
+++ b/src/components/TenseTable.vue
@@ -8,14 +8,9 @@
     <section id="gameDisplay">
       <template v-if="isGameStarted">
         <p v-html="shuffledSentenceList[currentDisplayNumber]" />
-        <p>{{ checkTenseType() }} {{ tenseType }}</p>
-        <button @click="showNextSentence()">Next Sentence</button>
+        <p id="answer">{{ getAnswerTenseType() }} {{ answerTenseType }}</p>
+        <button id="next-question" @click="showNextSentence()">Next Sentence</button>
       </template>
-      <!-- Add onClick function each cell? or add handler based on grid template area? -->
-      <!-- Use this.tenseType to match class name of each cell. 
-        If this.tenseType === cell's classname, 
-        THEN correct
-        THEN add one score -->
     </section>
 
     <section id="tense-table">
@@ -48,42 +43,50 @@
 
       <h3 class="simple">Simple</h3>
       <!-- Past Simple -->
-      <p v-if="isOccluded === false" class="past-simple" v-html="sentences.past.simple"></p>
-      <p v-else class="past-simple">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="past-simple" data-tense-type="past-simple" v-html="sentences.past.simple">
+      </p>
+      <p v-else class="past-simple" data-tense-type="past-simple" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth"
+          data-tense-type="past-simple" />
       </p>
 
       <!-- Past Continuous -->
+      <!-- Continuous / Progressive Header Toggler -->
       <h3 class="continuous" @click="switchContinuousProgressive()">
         <template v-if="isContinuous">Continuous</template>
         <template v-else>Progressive</template>
       </h3>
 
-      <p v-if="isOccluded === false" class="past-continuous" v-html="sentences.past.continuous"></p>
-      <p v-else class="past-continuous">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="past-continuous" data-tense-type="past-continuous"
+        v-html="sentences.past.continuous"></p>
+      <p v-else class="past-continuous" data-tense-type="past-continuous" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth"
+          data-tense-type="past-continuous" />
       </p>
 
       <!-- Past Perfect -->
       <h3 class="perfect">Perfect</h3>
 
-      <p v-if="isOccluded === false" class="past-perfect" v-html="sentences.past.perfect"></p>
-      <p v-else class="past-perfect">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="past-perfect" data-tense-type="past-perfect"
+        v-html="sentences.past.perfect"></p>
+      <p v-else class="past-perfect" data-tense-type="past-perfect" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth"
+          data-tense-type="past-perfect" />
       </p>
 
 
       <!-- Past Perfect Continuous -->
+      <!-- Continuous / Progressive Header Toggler -->
       <h3 class="perfect-continuous" @click="switchContinuousProgressive()">
         <template v-if="isContinuous">Perfect Continuous</template>
         <template v-else>Perfect Progressive</template>
       </h3>
 
-
-
-      <p v-if="isOccluded === false" class="past-perfect-continuous" v-html="sentences.past.perfectContinuous"></p>
-      <p v-else class="past-perfect-continuous">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="past-perfect-continuous" data-tense-type="perfect-continuous"
+        v-html="sentences.past.perfectContinuous"></p>
+      <p v-else class="past-perfect-continuous" data-tense-type="perfect-continuous" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" data-tense-type="perfect-continuous"
+          :width="occluderImageWidth" />
       </p>
 
 
@@ -92,34 +95,44 @@
 
       <!-- Present Simple -->
       <h3 class="repeated-heading">Simple</h3>
-      <p v-if="isOccluded === false" class="present-simple" v-html="sentences.present.simple"></p>
-      <p v-else class="present-simple">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="present-simple" data-tense-type="present-simple"
+        v-html="sentences.present.simple"></p>
+      <p v-else class="present-simple" data-tense-type="present-simple" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" data-tense-type="present-simple"
+          :width="occluderImageWidth" />
       </p>
 
 
       <!-- Present Continuous -->
       <h3 class="repeated-heading">Continuous/ Progressive</h3>
-      <p v-if="isOccluded === false" class="present-continuous" v-html="sentences.present.continuous"></p>
-      <p v-else class="present-continuous">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="present-continuous" data-tense-type="present-continuous"
+        v-html="sentences.present.continuous"></p>
+      <p v-else class="present-continuous" data-tense-type="present-continuous" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" data-tense-type="present-continuous"
+          :width="occluderImageWidth" />
       </p>
 
 
       <!-- Present Perfect -->
       <h3 class="repeated-heading">Perfect</h3>
-      <p v-if="isOccluded === false" class="present-perfect" v-html="sentences.present.perfect"></p>
-      <p v-else class="present-perfect">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+
+      <p v-if="isOccluded === false" class="present-perfect" data-tense-type="present-perfect"
+        v-html="sentences.present.perfect"></p>
+      <p v-else class="present-perfect" data-tense-type="present-perfect" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" data-tense-type="present-perfect"
+          :width="occluderImageWidth" />
       </p>
 
 
       <!-- Present Perfect Continuous -->
       <h3 class="repeated-heading">Perfect Continuous/ Perfect Progressive</h3>
-      <p v-if="isOccluded === false" class="present-perfect-continuous" v-html="sentences.present.perfectContinuous">
+
+      <p v-if="isOccluded === false" class="present-perfect-continuous" data-tense-type="present-perfect-continuous"
+        v-html="sentences.present.perfectContinuous">
       </p>
-      <p v-else class="present-perfect-continuous">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-else class="present-perfect-continuous" data-tense-type="present-perfect-continuous" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())"
+          data-tense-type="present-perfect-continuous" :width="occluderImageWidth" />
       </p>
 
 
@@ -129,33 +142,43 @@
 
       <!-- Future Simple -->
       <h3 class="repeated-heading">Simple</h3>
-      <p v-if="isOccluded === false" class="future-simple" v-html="sentences.future.simple"></p>
-      <p v-else class="future-simple">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+
+      <p v-if="isOccluded === false" class="future-simple" data-tense-type="future-simple"
+        v-html="sentences.future.simple"></p>
+      <p v-else class=" future-simple" data-tense-type="future-simple" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth"
+          data-tense-type="future-simple" />
       </p>
 
 
       <!-- Future Continuous -->
       <h3 class="repeated-heading">Continuous/ Progressive</h3>
-      <p v-if="isOccluded === false" class="future-continuous" v-html="sentences.future.continuous"></p>
-      <p v-else class="future-continuous">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="future-continuous" data-tense-type="future-continuous"
+        v-html="sentences.future.continuous">
+      </p>
+      <p v-else class="future-continuous" data-tense-type="future-continuous" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" data-tense-type="future-continuous"
+          :width="occluderImageWidth" />
       </p>
 
 
       <!-- Future Perfect -->
       <h3 class="repeated-heading">Perfect</h3>
-      <p v-if="isOccluded === false" class="future-perfect" v-html="sentences.future.perfect"></p>
-      <p v-else class="future-perfect">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="future-perfect" data-tense-type="future-perfect"
+        v-html="sentences.future.perfect"></p>
+      <p v-else class="future-perfect" data-tense-type="future-perfect" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" data-tense-type="future-perfect"
+          :width="occluderImageWidth" />
       </p>
 
 
       <!-- Future Perfect Continuous -->
       <h3 class="repeated-heading">Perfect Continuous/ Perfect Progressive</h3>
-      <p v-if="isOccluded === false" class="future-perfect-continuous" v-html="sentences.future.perfectContinuous"></p>
-      <p v-else class="future-perfect-continuous">
-        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth" />
+      <p v-if="isOccluded === false" class="future-perfect-continuous" data-tense-type="future-perfect-continuous"
+        v-html="sentences.future.perfectContinuous"></p>
+      <p v-else class="future-perfect-continuous" data-tense-type="future-perfect-continuous" @click="checkAnswer()">
+        <img :src="require('../assets/img/clouds/' + randomOccluderImage())" :width="occluderImageWidth"
+          data-tense-type="future-perfect-continuous" />
       </p>
 
 
@@ -176,7 +199,8 @@ export default {
   },
   data() {
     return {
-      tenseType: '',
+      answerTenseType: '',
+      selectedTenseType: '',
       playGame: `<button> Start Game </button>`,
       isGameStarted: false,
       isOccluded: false,
@@ -211,8 +235,6 @@ export default {
   methods: {
     switchContinuousProgressive() {
       this.isContinuous = !this.isContinuous;
-      console.log("switched!");
-      console.log(this.isContinuous);
     },
     startGame() {
       this.isGameStarted = true;
@@ -228,64 +250,77 @@ export default {
       }
       this.shuffledSentenceList = list;
     },
-    checkTenseType() {
+    getAnswerTenseType() {
       // find the corret tense type for the current displayed item in Game mode
       let currentSentence = this.shuffledSentenceList[this.currentDisplayNumber];
       switch (currentSentence) {
         // Past Tense Cases
         case this.sentences.past.simple:
           console.log("This is past simple tense!");
-          this.tenseType = "past-simple";
+          this.answerTenseType = "past-simple";
           break;
         case this.sentences.past.continuous:
           console.log("This is past continuous tense!");
-          this.tenseType = "past-continuous";
+          this.answerTenseType = "past-continuous";
           break;
         case this.sentences.past.perfect:
           console.log("This is past perfect tense!");
-          this.tenseType = "past-perfect";
+          this.answerTenseType = "past-perfect";
           break;
         case this.sentences.past.perfectContinuous:
           console.log("This is past perfect continuous tense!");
-          this.tenseType = "past-perfect-continuous";
+          this.answerTenseType = "past-perfect-continuous";
           break;
         // Present Tense Cases
         case this.sentences.present.simple:
           console.log("This is present simple tense!");
-          this.tenseType = "present-simple";
+          this.answerTenseType = "present-simple";
           break;
         case this.sentences.present.continuous:
           console.log("This is present continuous tense!");
-          this.tenseType = "present-continuous";
+          this.answerTenseType = "present-continuous";
           break;
         case this.sentences.present.perfect:
           console.log("This is present perfect tense!");
-          this.tenseType = "present-perfect";
+          this.answerTenseType = "present-perfect";
           break;
         case this.sentences.present.perfectContinuous:
           console.log("This is present perfect continuous tense!");
-          this.tenseType = "present-perfect-continuous";
+          this.answerTenseType = "present-perfect-continuous";
           break;
         // Future Tense Cases
         case this.sentences.future.simple:
           console.log("This is future simple tense!");
-          this.tenseType = "future-simple";
+          this.answerTenseType = "future-simple";
           break;
         case this.sentences.future.continuous:
           console.log("This is future continuous tense!");
-          this.tenseType = "future-continuous";
+          this.answerTenseType = "future-continuous";
           break;
         case this.sentences.future.perfect:
           console.log("This is future perfect tense!");
-          this.tenseType = "future-perfect";
+          this.answerTenseType = "future-perfect";
           break;
         case this.sentences.future.perfectContinuous:
           console.log("This is future perfect continuous tense!");
-          this.tenseType = "future-perfect-continuous";
+          this.answerTenseType = "future-perfect-continuous";
           break;
         default:
           console.log("Give me a sentence!");
       }
+    },
+    checkAnswer() {
+      this.getCellTenseType();
+      if (this.selectedTenseType === this.answerTenseType) {
+        console.log("correct!");
+        this.score = this.score + 1;
+      } else {
+        console.log("nah!");
+      }
+    },
+    getCellTenseType() {
+
+      this.selectedTenseType = event.target.getAttribute("data-tense-type");
     },
     showNextSentence() {
       this.currentDisplayNumber = this.currentDisplayNumber + 1;
@@ -311,6 +346,9 @@ export default {
         }
       }
       return sentenceList;
+    },
+    answer: function () {
+      return this.shuffledSentenceList[this.currentDisplayNumber]
     }
   }
 }


### PR DESCRIPTION
- [x] Add `data-tense-type` to all cells (all three layers of each cell)
- [x] Click each cell to return the tense type of the cell. E.g. click "I play." to `console.log` `present-simple`
- [x] Add a function to check if the displayed sentence type matches the clicked cell's tense type

<img width="975" alt="Screen Shot 2022-10-08 at 0 22 01" src="https://user-images.githubusercontent.com/85994674/194590439-4a7f4112-0b3e-4e8d-86c4-becaf7467bb1.png">

How do you allow Vue directives to be displayed on a new line with Prettier? (I have too many `data-tense-type` directives)
Reference: https://eslint.vuejs.org/rules/html-closing-bracket-newline.html